### PR TITLE
QRSResults JSON convertable

### DIFF
--- a/Sources/PeakSwift/Converter/Converter.swift
+++ b/Sources/PeakSwift/Converter/Converter.swift
@@ -9,7 +9,9 @@ import Foundation
 
 public protocol Converter {
     
-    associatedtype T: Decodable
+    associatedtype T: Codable
     
     func deserialize(toConvert: String) throws -> T
+    
+    func serialize(toConvert: T) throws -> String
 }

--- a/Sources/PeakSwift/Converter/JSONConverter.swift
+++ b/Sources/PeakSwift/Converter/JSONConverter.swift
@@ -7,7 +7,8 @@
 
 import Foundation
 
-public class JSONConverter<T: Decodable>: Converter {
+public class JSONConverter<T: Codable>: Converter {
+    
     
     public init(){
         
@@ -22,6 +23,23 @@ public class JSONConverter<T: Decodable>: Converter {
         do {
             let qrsResult: T = try JSONDecoder().decode(T.self, from: jsonData)
             return qrsResult
+        } catch {
+            throw ConverterError.JSONConvertionError
+        }
+    }
+    
+    public func serialize(toConvert: T) throws -> String {
+        
+        do {
+            let jsonData = try JSONEncoder().encode(toConvert)
+            let jsonString = String(data: jsonData, encoding: String.Encoding.utf8)
+            
+            if let result = jsonString {
+                return result
+            } else {
+                throw ConverterError.JSONConvertionError
+            }
+            
         } catch {
             throw ConverterError.JSONConvertionError
         }

--- a/Sources/PeakSwift/Models/Electrocardiogram.swift
+++ b/Sources/PeakSwift/Models/Electrocardiogram.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Electrocardiogram: Decodable {
+public struct Electrocardiogram: Codable {
     
     public let ecg: [Double]
     public let samplingRate: Double

--- a/Sources/PeakSwift/Models/QRSComplex.swift
+++ b/Sources/PeakSwift/Models/QRSComplex.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct QRSComplex: Decodable {
+public struct QRSComplex: Codable {
     
     public let rPeak: UInt
     let qWave: UInt?

--- a/Sources/PeakSwift/Models/QRSResult.swift
+++ b/Sources/PeakSwift/Models/QRSResult.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct QRSResult: Decodable {
+public struct QRSResult: Codable {
     public let qrsComplexes: [QRSComplex]
     public let electrocardiogram: Electrocardiogram
     public let cleanedElectrocardiogram: Electrocardiogram

--- a/Tests/PeakSwiftTests/ConverterTests.swift
+++ b/Tests/PeakSwiftTests/ConverterTests.swift
@@ -1,0 +1,34 @@
+//
+//  File.swift
+//  
+//
+//  Created by Nikita Charushnikov on 14.07.23.
+//
+
+import Foundation
+
+
+import XCTest
+@testable import PeakSwift
+
+
+final class ConverterTests: XCTestCase {
+    
+    func testJSONConverter() throws {
+        
+        let qrsComplex = [QRSComplex(rPeak: 1, qWave: 2, sWave: 3)]
+        let electrocardiogram = Electrocardiogram(ecg: [1,2,3], samplingRate: 1000)
+        let resultToConvert = QRSResult(qrsComlexes: qrsComplex, electrocardiogram: electrocardiogram, cleanedElectrocardiogram: electrocardiogram)
+        
+        let converter = JSONConverter<QRSResult>()
+        let jsonSerialized = try converter.serialize(toConvert: resultToConvert)
+        let actualDeserializedResults = try converter.deserialize(toConvert: jsonSerialized)
+        
+        XCTAssertEqual(resultToConvert.rPeaks, actualDeserializedResults.rPeaks)
+        XCTAssertEqual(resultToConvert.electrocardiogram.ecg, actualDeserializedResults.electrocardiogram.ecg)
+        XCTAssertEqual(resultToConvert.cleanedElectrocardiogram.ecg, actualDeserializedResults.cleanedElectrocardiogram.ecg)
+        XCTAssertEqual(resultToConvert.electrocardiogram.samplingRate, actualDeserializedResults.electrocardiogram.samplingRate)
+        XCTAssertEqual(resultToConvert.cleanedElectrocardiogram.samplingRate, actualDeserializedResults.cleanedElectrocardiogram.samplingRate)
+    }
+    
+}

--- a/Tests/PeakSwiftTests/Utils/QRSExpectedResult.swift
+++ b/Tests/PeakSwiftTests/Utils/QRSExpectedResult.swift
@@ -9,7 +9,7 @@ import Foundation
 import PeakSwift
 
 
-struct QRSExpectedTestResult: Decodable {
+struct QRSExpectedTestResult: Codable {
     public let qrsComplexes: [QRSComplex]
     public let electrocardiogram: Electrocardiogram
     


### PR DESCRIPTION
Hi @NumericalMax!

I created some utility functions, so it's possible to export the QRSResult as JSON String. 

It will be very useful, if we want to export QRSResults (e.g. In Peak Watch)

