### PR TITLE
Fix(Submodules): Change .gitmodules sources from ssh to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/berndporr/iir1
 [submodule "Sources/wavelib"]
 	path = Sources/wavelib
-	url = git@github.com:rafat/wavelib.git
+	url = https://github.com/rafat/wavelib


### PR DESCRIPTION
Hi @NumericalMax! 

I think I found a way how to fix the submodule issues. 

The problem is that wavelib submodule was configured to be fetched over ssh. It requires a well configured ssh client. 
If we change the fetching approach to https, the issue should be resolved since the wavelib repo is public and don't need to be fetched over ssh. 

With this approach, also non-ssh clients can integrate PeakSwift. 