### PR TITLE
Experiemnts/wrapper

### DIFF
--- a/Sources/Butterworth/WaveletsWrapper.mm
+++ b/Sources/Butterworth/WaveletsWrapper.mm
@@ -1,6 +1,6 @@
 //
 //  WaveletsWrapper.cpp
-//  
+//
 //
 //  Created by Nikita Charushnikov on 01.08.23.
 //
@@ -11,7 +11,7 @@
 
 @implementation WaveletsWrapper
 
-- (NSMutableArray<NSNumber *> *)stationaryWaveletTransformation: (double[]) signal :(int) signalSize :(NSString *) wavelet :(int) level {
+- (void)stationaryWaveletTransformation: (double[]) signal :(double[]) result  :(int) signalSize :(NSString *) wavelet :(int) level {
     
     wave_object wave_obj;
     wt_object wavelet_obj;
@@ -26,17 +26,15 @@
     
     swt(wavelet_obj, signal);
     
-    NSMutableArray *waveletsOutput = [NSMutableArray array];
-    
     for (int i = 0; i < wavelet_obj->outlength; ++i) {
         const double output = wavelet_obj->output[i];
-        [waveletsOutput addObject:[NSNumber numberWithDouble:output]];
+        result[i] = output;
     }
     
     wave_free(wave_obj);
     wt_free(wavelet_obj);
     
-    return waveletsOutput;
 }
 
 @end
+

--- a/Sources/Butterworth/include/ButterworthWrapper.h
+++ b/Sources/Butterworth/include/ButterworthWrapper.h
@@ -11,11 +11,11 @@
 
 @interface ButterworthWrapper : NSObject
 
-- (NSMutableArray<NSNumber *> *) butterworth: (NSArray<NSNumber *> *) signal :(NSNumber *) order :(NSNumber*)samplingRate :(NSNumber*) lowCutFrequency :(NSNumber*) highCutFrequency;
+- (void)butterworth: (double[]) signal :(double[]) filteredResult :(int) vectorLength :(double) lowCutFrequency :(double) highCutFrequency :(int) order :(double) samplingRate;
 
-- (NSMutableArray<NSNumber *> *) butterworthBandstop: (NSArray<NSNumber *> *) signal :(NSNumber *) order :(NSNumber*)samplingRate :(NSNumber*) lowCutFrequency :(NSNumber*) highCutFrequency;
+- (void)butterworthBandstop: (double[]) signal :(double[]) filteredResult :(int) vectorLength :(double) lowCutFrequency :(double) highCutFrequency :(int) order :(double) samplingRate;
 
-- (NSMutableArray<NSNumber *> *) butterworthHighPassForwardBackward: (NSArray<NSNumber *> *) signal :(NSNumber *) order :(NSNumber*)samplingRate :(NSNumber*) lowCutFrequency;
+- (void)butterworthHighPassForwardBackward: (double[]) signal :(double[]) filteredResult :(int) vectorLength :(double) lowCutFrequency :(int) order :(double) samplingRate;
 
 - (void)butterworthLowPassForwardBackward: (double[]) signal :(double[]) filteredResult :(int) vectorLength :(double) normalizedLowCutFrequency :(int) order :(double) samplingRate;
 

--- a/Sources/Butterworth/include/WaveletsWrapper.h
+++ b/Sources/Butterworth/include/WaveletsWrapper.h
@@ -11,6 +11,6 @@
 
 @interface WaveletsWrapper : NSObject
 
-- (NSMutableArray<NSNumber *> *)stationaryWaveletTransformation: (double[]) signal :(int) signalSize :(NSString *) wavelet :(int) level;
+- (void)stationaryWaveletTransformation: (double[]) signal :(double[]) result  :(int) signalSize :(NSString *) wavelet :(int) level;
 
 @end

--- a/Sources/PeakSwift/Utils/Helper/Filter/Butterworth.swift
+++ b/Sources/PeakSwift/Utils/Helper/Filter/Butterworth.swift
@@ -39,15 +39,13 @@ public class Butterworth {
     ///   - sampleRate: the sampling rate of signal
     /// - Returns: Filtered signal with frequency in range between lowCutFrequency and highCutFrequency
     public func butterworth(signal: [Double], order: Order, lowCutFrequency: Double, highCutFrequency: Double, sampleRate: Double) -> [Double] {
-        let signalObjC : [NSNumber] = signal as [NSNumber]
-        let lowCutObjC = NSNumber(value: lowCutFrequency)
-        let highCutObjC = NSNumber(value: highCutFrequency)
-        let sampleRateObjC = NSNumber(value: sampleRate)
-        let orderObjC = NSNumber(value: order.rawValue)
         
-        let filteredSignal = butterworthWrapper.butterworth(signalObjC, orderObjC, sampleRateObjC, lowCutObjC, highCutObjC)
+        var signalToFilter = [Double](signal)
+        var highpassFilteredSignal = [Double](repeating: 0.0, count: signal.count)
         
-        return filteredSignal as! [Double]
+        butterworthWrapper.butterworth(&signalToFilter, &highpassFilteredSignal, Int32(signal.count), lowCutFrequency, highCutFrequency, Int32(order.rawValue), sampleRate)
+        
+        return highpassFilteredSignal
     }
     
     
@@ -59,33 +57,31 @@ public class Butterworth {
     ///   - sampleRate: the sampling rate of signal
     /// - Returns: The filter signal without frequencies below the lowCutFrequency
     public func butterworthForwardBackward(signal: [Double], order: Order, lowCutFrequency: Double, sampleRate: Double) -> [Double] {
-        let signalObjC : [NSNumber] = signal as [NSNumber]
-        let lowCutObjC = NSNumber(value: lowCutFrequency)
-        let sampleRateObjC = NSNumber(value: sampleRate)
-        let orderObjC = NSNumber(value: order.rawValue)
         
-        let filteredSignal = butterworthWrapper.butterworthHighPassForwardBackward(signalObjC, orderObjC, sampleRateObjC, lowCutObjC)
+        var signalToFilter = [Double](signal)
+        var highpassFilteredSignal = [Double](repeating: 0.0, count: signal.count)
         
-        return filteredSignal as! [Double]
+        butterworthWrapper.butterworthHighPassForwardBackward(&signalToFilter, &highpassFilteredSignal, Int32(signal.count), lowCutFrequency, Int32(order.rawValue), sampleRate)
+        
+        return highpassFilteredSignal
         
     }
     
     func butterworthBandStop(signal: [Double], order: Order, lowCutFrequency: Double, highCutFrequency: Double, sampleRate: Double) -> [Double] {
-        let signalObjC : [NSNumber] = signal as [NSNumber]
-        let lowCutObjC = NSNumber(value: lowCutFrequency)
-        let highCutObjC = NSNumber(value: highCutFrequency)
-        let sampleRateObjC = NSNumber(value: sampleRate)
-        let orderObjC = NSNumber(value: order.rawValue)
+        var signalToFilter = [Double](signal)
+        var bandStopFilteredSignal = [Double](repeating: 0.0, count: signal.count)
         
-        let filteredSignal = butterworthWrapper.butterworthBandstop(signalObjC, orderObjC, sampleRateObjC, lowCutObjC, highCutObjC)
+        butterworthWrapper.butterworthBandstop(&signalToFilter, &bandStopFilteredSignal, Int32(bandStopFilteredSignal.count), lowCutFrequency, highCutFrequency, Int32(order.rawValue), sampleRate)
         
-        return filteredSignal as! [Double]
+        return bandStopFilteredSignal
     }
 
     func butterworthLowPassForwardBackward(signal: [Double], order: Order, normalizedHighCutFrequency: Double, sampleRate: Double) -> [Double] {
         var signalToFilter = [Double](signal)
         var lowPassFilteredSignal = [Double](repeating: 0.0, count: signal.count)
+        
         butterworthWrapper.butterworthLowPassForwardBackward(&signalToFilter, &lowPassFilteredSignal, Int32(signal.count), normalizedHighCutFrequency, Int32(order.rawValue), sampleRate)
+        
         return lowPassFilteredSignal
     }
     

--- a/Sources/PeakSwift/Utils/Helper/Wavelets/StationaryWaveletTransformation.swift
+++ b/Sources/PeakSwift/Utils/Helper/Wavelets/StationaryWaveletTransformation.swift
@@ -28,12 +28,14 @@ class StationaryWaveletTransformation {
             fatalError("For applying stationary wavelets transformation: signal.size% 2^^level == 0")
         }
         
+        let outputWaveletTransformationSize = signalSize * (level + 1)
+        
         var inputSignal = [Double](signal)
+        var outputWaveletTransformation = [Double].init(repeating: 0.0, count: outputWaveletTransformationSize)
         
-        let outputWaveletTransformationRaw = waveletsWrapper.stationaryWaveletTransformation(&inputSignal, Int32(signalSize), wavelet.rawValue, Int32(level))
+        waveletsWrapper.stationaryWaveletTransformation(&inputSignal, &outputWaveletTransformation, Int32(signalSize), wavelet.rawValue, Int32(level))
         
-        let outputWaveletTransformation = outputWaveletTransformationRaw as! [Double]
-        
+       
         return extractCoefficients(waveletOutput: outputWaveletTransformation, level: level)
     }
     


### PR DESCRIPTION
Hi @LeonNissen! 👋 

With this PR, I improved the runtime performance. 

The problem was that we were copying vectors between Objective-C wrapper and Swift which lowered the performance. 

I improved it by implementing the following workflow:



- All arrays should be initialized in the Swift code
- Only a pointer to the array should be passed to the header files

This drastically improved the performance.  Even Kalidas is now competitive to NeuroKit. See benchmarks below.

Comparison runtimes of PeakSwift before and after.
![benchmark_improved_wrapper](https://github.com/CardioKit/PeakSwift/assets/51714672/8a20eba2-61f0-4713-8fb3-f6ea914b349c)

Comparison runtimes  with NeuroKit (snapshot now)
![benchamrk_improved_wrapper](https://github.com/CardioKit/PeakSwift/assets/51714672/499cba3d-0aab-4085-b5be-6844e9f54ca5)



